### PR TITLE
Docs/issue 27 fix spelling mistake in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Streaming Query
       print(row)
 
 
-the output of the code will be something like following, as for streaming query is unbouded, you can add your flow control to terminate the loop.
+the output of the code will be something like following, as for streaming query is unbounded, you can add your flow control to terminate the loop.
 
 .. code-block:: shell
 


### PR DESCRIPTION
unbouded -> unbounded