### PR TITLE
CI/issue 20 fix the release action in the release workflow by passing `tag_name` and `token` explicitly

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,10 +10,28 @@ jobs:
         os: [ ubuntu-20.04 , windows-2019, macos-11 ]
     steps:
       - uses: actions/checkout@v4
+      - name: Get proton-python-driver tag
+        id: get_tag_name
+        if: ${{ !startsWith( matrix.os, 'windows' ) }}
+        run: |
+          VERSION=`grep '^VERSION' proton_driver/__init__.py \
+          | sed 's/^VERSION = (//g' \
+          | sed 's/).*//g' \
+          | sed 's/, /./g'`
+          VERSION=v$VERSION
+          echo $VERSION
+          echo "tag_name=$VERSION" >> $GITHUB_OUTPUT
+      - name: Get proton-python-driver tag(windows)
+        if: ${{ startsWith( matrix.os, 'windows' ) }}
+        id: get_tag_name_win
+        shell: pwsh
+        run: |
+          $VERSION=((Get-Content proton_driver/__init__.py | Select-String -Pattern '^VERSION') -replace "^VERSION = \((\d+), (\d+), (\d+)\)","v`$1.`$2.`$3")
+          Write-Output $VERSION
+          Write-Output "tag_name=$VERSION" >> $env:GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
-        if: ${{ matrix.os=='ubuntu-20.04' }}
-        id: qemu
+        if: ${{ startsWith( matrix.os, 'ubuntu' ) }}
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
@@ -27,5 +45,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: wheelhouse/*.whl
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           generate_release_notes: true
+          tag_name: ${{ join(steps.*.outputs.tag_name, '') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,6 @@ archs = [ "aarch64", "x86_64" ]
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+archs = [ "arm64", "x86_64" ]
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
- get version from `proton_driver/__init__.py`.
- use `env: GITHUB_TOKEN` to pass the token to action `action-gh-release`.