### PR TITLE
Add publish-to-pypi action job

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 , windows-2019, macos-11 ]
+        os: [ ubuntu-20.04 , windows-2019, macos-12 ]
     steps:
       - uses: actions/checkout@v4
       - name: Get proton-python-driver tag
@@ -49,3 +49,30 @@ jobs:
           tag_name: ${{ join(steps.*.outputs.tag_name, '') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: wheelhouse/*.whl
+  
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    needs:
+      - build_wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/proton-driver
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        username: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
[macos-11 is not supported by github action](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#:~:text=The%20macOS%2011%20runner%20image%20will%20be%20removed%20on%206/28/2024.).