### PR TITLE
Unpin cibuildwheel container images so the release can build 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,6 +173,27 @@ jobs:
           python -m pip install pytest
           python -m pytest tests/test_freethreading.py::ExtensionConcurrencyTestCase -v
 
+  # The release workflow is the only other place cibuildwheel runs, so its
+  # config rots invisibly: the stale musllinux_1_1 image pin killed release
+  # run 27423060149 at startup despite fully green PR checks. cibuildwheel
+  # resolves every image option upfront (verified: a bad musllinux pin fails
+  # this job in seconds even though it builds a manylinux target), so
+  # building one real wheel here surfaces config breakage — and runs the
+  # in-container block-import smoke test — on every PR instead of at
+  # release time.
+  cibuildwheel-smoke:
+    name: cibuildwheel config + single-wheel build
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build one wheel through cibuildwheel
+        # Keep the version in lockstep with the release workflow
+        # (.github/workflows/actions.yml) — validating with a different
+        # cibuildwheel than the release uses defeats the purpose.
+        uses: pypa/cibuildwheel@v3.4.1
+        with:
+          only: cp314t-manylinux_x86_64
+
   coveralls-finished:
     name: Indicate completion to coveralls.io
     needs: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
   0.2.10 had shipped one, so interpreters without a prebuilt wheel had
   no installable artifact. The sdist bundles the pre-generated Cython C
   and builds without Cython.
+- Linux wheels are built on the `manylinux_2_28` / `musllinux_1_2`
+  images (cibuildwheel 3.x removed `musllinux_1_1`, and the frozen
+  `manylinux2014` images predate Python 3.14). auditwheel still grades
+  each wheel by the symbols it actually needs — the extensions grade to
+  `manylinux2014`/`manylinux_2_17`, so old-glibc compatibility is
+  preserved.
 
 ## [0.2.3] - 2022-02-07
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,20 +40,11 @@ test-extras = []
 
 container-engine = "docker"
 
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-manylinux-ppc64le-image = "manylinux2014"
-manylinux-s390x-image = "manylinux2014"
-manylinux-pypy_x86_64-image = "manylinux2014"
-manylinux-pypy_i686-image = "manylinux2014"
-manylinux-pypy_aarch64-image = "manylinux2014"
-
-musllinux-x86_64-image = "musllinux_1_1"
-musllinux-i686-image = "musllinux_1_1"
-musllinux-aarch64-image = "musllinux_1_1"
-musllinux-ppc64le-image = "musllinux_1_1"
-musllinux-s390x-image = "musllinux_1_1"
+# No image pins: cibuildwheel 3.x rejects the musllinux_1_1 alias outright,
+# and the manylinux2014 images froze at CentOS 7 EOL without Python 3.14 —
+# neither can build cp314/cp314t. The 3.4.1 defaults (manylinux_2_28 /
+# musllinux_1_2) carry every interpreter we target; older-glibc systems
+# install from the sdist.
 
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Release run [27423060149](https://github.com/timeplus-io/proton-python-driver/actions/runs/27423060149) for v0.3.0 failed at cibuildwheel startup:

> cibuildwheel: cibuildwheel 3.x does not support the image 'musllinux_1_1'.

Two stale image pins in `pyproject.toml` block the release:

1. `musllinux_1_1` — removed by cibuildwheel 3.x, hard error.
2. `manylinux2014` — the images froze at CentOS 7 EOL (June 2024) and do not contain Python 3.14, so they could not build the cp314/cp314t wheels this release exists for.

Fix: drop the pins and use the cibuildwheel 3.4.1 defaults (`manylinux_2_28` / `musllinux_1_2`).

**Why no PR check caught this:** the release workflow is the only place cibuildwheel runs, so its config can rot invisibly — PR #69 was fully green while the release config was broken. This PR closes that gap: the test workflow now builds one real wheel (cp314t) through cibuildwheel on every PR. cibuildwheel resolves all image options upfront, so any config rot fails the job in seconds instead of surfacing at release time.

Verified locally before opening this PR:
- `cibuildwheel --print-build-identifiers` yields the full set: cp38–cp314t + pp311, x86_64 + aarch64, manylinux + musllinux. (Note: this command alone does **not** validate images — verified empirically — which is why the guard builds a real wheel.)
- A real cp314t wheel built end-to-end through cibuildwheel with the block-import smoke test passing inside the container.
- auditwheel grades the built wheel to `manylinux2014`/`manylinux_2_17` — the extensions only use old glibc symbols, so compatibility with old distros is preserved despite the newer build image.
- Reintroducing the bad `musllinux_1_1` pin makes the new guard job fail in ~2 seconds, proving it catches this failure class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)