### PR TITLE
Use macos-14 runner for release wheels (macos-13 retired)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,10 @@ jobs:
       contents: write
     strategy:
       matrix:
-        os: [ ubuntu-22.04 , windows-2022, macos-13 ]
+        # macos-13 (Intel) runners are retired; macos-14 is Apple Silicon
+        # (arm64). cibuildwheel builds arm64 natively and cross-builds the
+        # x86_64 wheels (x86_64 can't be tested on an arm64 runner).
+        os: [ ubuntu-22.04 , windows-2022, macos-14 ]
     steps:
       - uses: actions/checkout@v4
       - name: Get proton-python-driver tag


### PR DESCRIPTION
## Problem
GitHub is retiring the Intel **macos-13** runners. The 0.3.0 release run
(workflow_dispatch on `develop`) built the Linux + Windows wheels fine —
**including all `cp314t` free-threaded wheels** — but the macOS leg sat
`queued` indefinitely waiting for a runner that no longer exists. Because
`publish-to-pypi` needs *every* `build_wheels` matrix job, that stuck leg
blocked the PyPI publish entirely. The stuck run was cancelled.

## Fix
Switch the release matrix `macos-13` → `macos-14` (Apple Silicon / arm64).
cibuildwheel builds the arm64 wheels natively and cross-builds the x86_64
ones (x86_64 wheels can't be *tested* on an arm64 runner, only built).

## Validation
The released `cp314t` wheel itself is already proven good: pulled from the
v0.3.0 GitHub release and tested in a free-threaded CPython 3.14.4 env
against a live `timeplusd` 3.3.1.246 FT server — import keeps the GIL off,
stream create/insert/read works, and 16 threads × 25 concurrent queries all
succeed with the GIL staying disabled. This PR only unblocks the macOS build
+ PyPI publish; it does not touch shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)